### PR TITLE
Changed the Irony nuget package to 0.96 to fix Virtuals for associate sessions

### DIFF
--- a/MAT.SQLRace.BaseExampleLoadSSN/MAT.SQLRace.BaseExampleLoadSSN.csproj
+++ b/MAT.SQLRace.BaseExampleLoadSSN/MAT.SQLRace.BaseExampleLoadSSN.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SQLRace.CreateSessionWithMultipleParameters/MAT.SQLRace.CreateSessionWithMultipleParameters.csproj
+++ b/MAT.SQLRace.CreateSessionWithMultipleParameters/MAT.SQLRace.CreateSessionWithMultipleParameters.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Confluent.Kafka" Version="0.11.6" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="librdkafka.redist" Version="0.11.6" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SQLRace.FileLoaderSample/MAT.SQLRace.FileLoaderSample.csproj
+++ b/MAT.SQLRace.FileLoaderSample/MAT.SQLRace.FileLoaderSample.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />
     <PackageReference Include="MAT.OCS.FFC.Configuration.Format" Version="1.5.0" />

--- a/MAT.SQLRace.HelloCreateSSN2FromZeroWithParameters/MAT.SQLRace.HelloCreateSSN2FromZeroWithParameters.csproj
+++ b/MAT.SQLRace.HelloCreateSSN2FromZeroWithParameters/MAT.SQLRace.HelloCreateSSN2FromZeroWithParameters.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SQLRace.HelloData/MAT.SQLRace.HelloData.csproj
+++ b/MAT.SQLRace.HelloData/MAT.SQLRace.HelloData.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SQLRace.LoadSessionFromDatabaseAndReadParameters/MAT.SQLRace.LoadSessionFromDatabaseAndReadParameters.csproj
+++ b/MAT.SQLRace.LoadSessionFromDatabaseAndReadParameters/MAT.SQLRace.LoadSessionFromDatabaseAndReadParameters.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SqlRace.Functions.HelloDotNet/MAT.SqlRace.Functions.HelloDotNet.csproj
+++ b/MAT.SqlRace.Functions.HelloDotNet/MAT.SqlRace.Functions.HelloDotNet.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />
     <PackageReference Include="MAT.OCS.FFC.Configuration.Format" Version="1.5.0" />

--- a/MAT.SqlRace.ServerListener/MAT.SqlRace.ServerListener.csproj
+++ b/MAT.SqlRace.ServerListener/MAT.SqlRace.ServerListener.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MAT.SqlRace.StandaloneRecorder/MAT.SqlRace.StandaloneRecorder.csproj
+++ b/MAT.SqlRace.StandaloneRecorder/MAT.SqlRace.StandaloneRecorder.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.ATLAS.SupportFiles" Version="*" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />

--- a/MESL.SqlRace.Examples.Sessions.CSharp/MESL.SqlRace.Examples.Sessions.CSharp.csproj
+++ b/MESL.SqlRace.Examples.Sessions.CSharp/MESL.SqlRace.Examples.Sessions.CSharp.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.14.0" />
     <PackageReference Include="IronSnappy" Version="1.3.0" />
-    <PackageReference Include="Irony" Version="1.2.0" />
+    <PackageReference Include="Irony" Version="0.96.0" />
     <PackageReference Include="MAT.OCS.Core" Version="2.1.15" />
     <PackageReference Include="MAT.OCS.FFC" Version="1.5.0" />
     <PackageReference Include="MAT.OCS.FFC.Configuration.Format" Version="1.5.0" />


### PR DESCRIPTION
Changed the Irony package version back to 0.96 instead of 1.2 as the newer version is causing issues with accessing virtuals in associate sessions. Downgrading the package seems to have fixed it. 