### PR TITLE
Fix python script for net 6

### DIFF
--- a/Python/main.py
+++ b/Python/main.py
@@ -15,7 +15,7 @@ sql_race_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MES
 automation_api_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MAT.Atlas.Automation.Api.dll"
 automation_client_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MAT.Atlas.Automation.Client.dll"
 # The connection string to the database containing our sessions
-connection_string = r"Server=MCLA-F8ZLSQ3\LOCAL;Initial Catalog=SQLRACE01_LOCAL;Trusted_Connection=True;"
+connection_string = r"Server=CLU-LDF01\LOCAL;Initial Catalog=SQLRACE01_2019;Trusted_Connection=True;"
 
 # Configure Pythonnet and reference the required assemblies for dotnet and SQL Race
 clr.AddReference("System.Collections")

--- a/Python/main.py
+++ b/Python/main.py
@@ -1,8 +1,13 @@
 import os
 import time
-import clr # Pythonnet
 import subprocess
 import threading
+
+from pythonnet import load
+
+load("coreclr", runtime_config=r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MAT.Atlas.Host.runtimeconfig.json")
+
+import clr # Pythonnet
 
 # The path to the main SQL Race DLL. This is the default location when installed with Atlas 10
 sql_race_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll"
@@ -10,7 +15,7 @@ sql_race_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MES
 automation_api_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MAT.Atlas.Automation.Api.dll"
 automation_client_dll_path = r"C:\Program Files\McLaren Applied Technologies\ATLAS 10\MAT.Atlas.Automation.Client.dll"
 # The connection string to the database containing our sessions
-connection_string = r"Server=CLU-LDF01\LOCAL;Initial Catalog=SQLRACE01_2019;Trusted_Connection=True;"
+connection_string = r"Server=MCLA-F8ZLSQ3\LOCAL;Initial Catalog=SQLRACE01_LOCAL;Trusted_Connection=True;"
 
 # Configure Pythonnet and reference the required assemblies for dotnet and SQL Race
 clr.AddReference("System.Collections")


### PR DESCRIPTION
This change is to fix Python sample code to load .NET 6 SQLRace API dlls as found in issue #37.