### PR TITLE
Update StandaloneRecorder and ServerListener Example to use new SetSQLRaceConnection delete options

### DIFF
--- a/MAT.SqlRace.ServerListener/Program.cs
+++ b/MAT.SqlRace.ServerListener/Program.cs
@@ -41,7 +41,13 @@ namespace MAT.SqlRace.ServerListenerLive
             Core.ConfigureServer(true, new IPEndPoint(IPAddress.Parse(ServerListenerIpAddress), ServerListenerPortNumber));
             var sessionManager = SessionManager.CreateSessionManager();
             var recordersConfiguration = RecordersConfiguration.GetRecordersConfiguration();
-            recordersConfiguration.AddConfiguration(Guid.NewGuid(), recorderDbEngine, dataSource, dataSource, connectionString, false);
+            recordersConfiguration.AddConfiguration(
+                Guid.NewGuid(),
+                recorderDbEngine,
+                dataSource, 
+                dataSource, 
+                connectionString, 
+                0); // DeleteSessionOnClose: 0 - no delete, 1 - delete the session on close, 2 - delete the DB
 
 
             Console.WriteLine("Creating new Session");

--- a/MAT.SqlRace.StandaloneRecorder/Program.cs
+++ b/MAT.SqlRace.StandaloneRecorder/Program.cs
@@ -56,7 +56,12 @@ namespace MAT.SqlRace.StandaloneRecorder
                 recorder = Recorders.CreateDataServerTelemetryRecorder();
                 recorder.SetSessionIdentifier("%y%m%d%H%M%S");
                 recorder.OnStatusChanged += recorder_OnStatusChanged;
-                recorder.SetSQLRaceConnection(Guid.NewGuid(), dbEngine, dataSource, sqlConnectionString, sqlConnectionString, false);
+                recorder.SetSQLRaceConnection(
+                    Guid.NewGuid(),
+                    dbEngine, dataSource,
+                    sqlConnectionString,
+                    sqlConnectionString,
+                    0); // DeleteSessionOnClose: 0 - no delete, 1 - delete the session on close, 2 - delete the DB
 
                 Console.WriteLine("Getting Available Server List");
                 recorder.RefreshServerList();


### PR DESCRIPTION
This updates the `StandaloneRecorder` and `ServerListener` example to align with the breaking `SupportFiles` API change to `SetSQLRaceConnection`.

The `deleteSessionOnClose` parameter has changed from a `boolean` to an `integer` to support additional deletion behaviors. The example has been updated to pass the new integer value and includes an inline comment describing the available options.

This ensures the example builds correctly with the latest `SupportFiles` and provides guidance for downstream consumers updating their code.