### PR TITLE
Add and expand MATLAB SQL Race examples

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -7,55 +7,58 @@ A task-based index: find the example you need by what you want to accomplish.
 | How do I... | C# | Python | MATLAB |
 |------------|-----|--------|--------|
 | Load a session from a `.ssn2` file? | [`01-load-session-from-file.cs`](snippets/csharp/getting-started/01-load-session-from-file.cs) | [`01_load_session.py`](snippets/python/getting-started/01_load_session.py) | [`load_session.m`](snippets/matlab/getting-started/load_session.m) |
-| Load a session from a database? | [`02-load-session-from-database.cs`](snippets/csharp/getting-started/02-load-session-from-database.cs) | [`01_load_session.py`](snippets/python/getting-started/01_load_session.py) | [`load_session.m`](snippets/matlab/getting-started/load_session.m) |
+| Load a session from a database? | [`02-load-session-from-database.cs`](snippets/csharp/getting-started/02-load-session-from-database.cs) | [`01_load_session.py`](snippets/python/getting-started/01_load_session.py) | [`load_session_from_database.m`](snippets/matlab/getting-started/load_session_from_database.m) |
 | Read parameter samples? | [`03-read-parameter-samples.cs`](snippets/csharp/getting-started/03-read-parameter-samples.cs) | [`02_read_parameters.py`](snippets/python/getting-started/02_read_parameters.py) | [`read_parameters.m`](snippets/matlab/getting-started/read_parameters.m) |
-| Create a session and write data? | [`04-create-session-write-data.cs`](snippets/csharp/getting-started/04-create-session-write-data.cs) | — | — |
+| Create a session and write data? | [`04-create-session-write-data.cs`](snippets/csharp/getting-started/04-create-session-write-data.cs) | — | [`create_session_write_data.m`](snippets/matlab/getting-started/create_session_write_data.m) |
 | Find sessions by metadata? | [`05-query-sessions-by-metadata.cs`](snippets/csharp/getting-started/05-query-sessions-by-metadata.cs) | [`03_query_sessions.py`](snippets/python/getting-started/03_query_sessions.py) | [`query_sessions.m`](snippets/matlab/getting-started/query_sessions.m) |
 | Verify MATLAB + SQL Race setup? | — | — | [`diagnose_setup.m`](snippets/matlab/getting-started/diagnose_setup.m) |
+| List all parameters in a session? | — | — | [`list_parameters.m`](snippets/matlab/getting-started/list_parameters.m) |
 
 ## Data Access
 
 | How do I... | C# | Python | MATLAB |
 |------------|-----|--------|--------|
-| Read samples in a time range? | [`read-samples-between.cs`](snippets/csharp/data-access/read-samples-between.cs) | [`read_samples_to_list.py`](snippets/python/data-access/read_samples_to_list.py) | [`extract_to_timetable.m`](snippets/matlab/data-access/extract_to_timetable.m) |
-| Downsample / subsample data? | [`read-subsampled-data.cs`](snippets/csharp/data-access/read-subsampled-data.cs) | — | — |
-| Read data backwards (reverse iteration)? | [`reverse-iteration.cs`](snippets/csharp/data-access/reverse-iteration.cs) | — | — |
+| Read samples in a time range? | [`read-samples-between.cs`](snippets/csharp/data-access/read-samples-between.cs) | [`read_samples_to_list.py`](snippets/python/data-access/read_samples_to_list.py) | [`read_samples_between.m`](snippets/matlab/data-access/read_samples_between.m) |
+| Downsample / subsample data? | [`read-subsampled-data.cs`](snippets/csharp/data-access/read-subsampled-data.cs) | — | [`subsampled_read.m`](snippets/matlab/data-access/subsampled_read.m) |
+| Read data backwards (reverse iteration)? | [`reverse-iteration.cs`](snippets/csharp/data-access/reverse-iteration.cs) | — | [`reverse_iteration.m`](snippets/matlab/data-access/reverse_iteration.m) |
 | Align parameters at different rates? | [`multi-rate-alignment.cs`](snippets/csharp/data-access/multi-rate-alignment.cs) | — | — |
 | Read many parameters efficiently? | [`bulk-parameter-read.cs`](snippets/csharp/data-access/bulk-parameter-read.cs) | [`multi_parameter_extract.py`](snippets/python/data-access/multi_parameter_extract.py) | [`multi_channel_read.m`](snippets/matlab/data-access/multi_channel_read.m) |
-| Handle missing or invalid data? | [`data-status-filtering.cs`](snippets/csharp/data-access/data-status-filtering.cs) | — | — |
+| Handle missing or invalid data? | [`data-status-filtering.cs`](snippets/csharp/data-access/data-status-filtering.cs) | — | [`data_status_filtering.m`](snippets/matlab/data-access/data_status_filtering.m) |
 | Build timestamp arrays for GetData? | [`timestamp-array-construction.cs`](snippets/csharp/data-access/timestamp-array-construction.cs) | — | — |
 | Export data to pandas? | — | [`export_to_pandas.py`](snippets/python/data-access/export_to_pandas.py) | — |
 | Export data to MATLAB timetable? | — | — | [`extract_to_timetable.m`](snippets/matlab/data-access/extract_to_timetable.m) |
 | Get per-segment statistics? | — | — | [`segment_statistics.m`](snippets/matlab/data-access/segment_statistics.m) |
+| Plot a set of parameters? | — | — | [`plot_parameters.m`](snippets/matlab/data-access/plot_parameters.m) |
 
 ## Session Management
 
-| How do I... | C# | Python |
-|------------|-----|--------|
-| Find sessions in a date range? | [`query-with-composite-filter.cs`](snippets/csharp/session-management/query-with-composite-filter.cs) | [`03_query_sessions.py`](snippets/python/getting-started/03_query_sessions.py) |
-| Read and write session metadata? | [`session-metadata-crud.cs`](snippets/csharp/session-management/session-metadata-crud.cs) | — |
-| Add annotations to a session? | [`marker-management.cs`](snippets/csharp/session-management/marker-management.cs) | — |
-| Work with laps and segments? | [`lap-and-segment-management.cs`](snippets/csharp/session-management/lap-and-segment-management.cs) | — |
-| Define and read events? | [`event-definitions-and-data.cs`](snippets/csharp/session-management/event-definitions-and-data.cs) | [`04_extract_events.py`](snippets/python/getting-started/04_extract_events.py) |
-| Associate sessions together? | [`session-association.cs`](snippets/csharp/session-management/session-association.cs) | — |
-| Resolve parameter units? | [`parameter-unit-resolution.cs`](snippets/csharp/session-management/parameter-unit-resolution.cs) | — |
+| How do I... | C# | Python | MATLAB |
+|------------|-----|--------|--------|
+| Find sessions in a date range? | [`query-with-composite-filter.cs`](snippets/csharp/session-management/query-with-composite-filter.cs) | [`03_query_sessions.py`](snippets/python/getting-started/03_query_sessions.py) | [`query_sessions.m`](snippets/matlab/getting-started/query_sessions.m) |
+| Read and write session metadata? | [`session-metadata-crud.cs`](snippets/csharp/session-management/session-metadata-crud.cs) | — | [`session_metadata.m`](snippets/matlab/session-management/session_metadata.m) |
+| Add annotations to a session? | [`marker-management.cs`](snippets/csharp/session-management/marker-management.cs) | — | [`marker_management.m`](snippets/matlab/session-management/marker_management.m) |
+| Work with laps and segments? | [`lap-and-segment-management.cs`](snippets/csharp/session-management/lap-and-segment-management.cs) | — | [`lap_segment_management.m`](snippets/matlab/session-management/lap_segment_management.m) |
+| Define and read events? | [`event-definitions-and-data.cs`](snippets/csharp/session-management/event-definitions-and-data.cs) | [`04_extract_events.py`](snippets/python/getting-started/04_extract_events.py) | [`event_extraction.m`](snippets/matlab/session-management/event_extraction.m) |
+| Associate sessions together? | [`session-association.cs`](snippets/csharp/session-management/session-association.cs) | — | — |
+| Resolve parameter units? | [`parameter-unit-resolution.cs`](snippets/csharp/session-management/parameter-unit-resolution.cs) | — | [`parameter_unit_resolution.m`](snippets/matlab/configuration/parameter_unit_resolution.m) |
 
 ## Live Data
 
-| How do I... | C# |
-|------------|-----|
-| React to new laps? | [`subscribe-to-lap-events.cs`](snippets/csharp/live-data/subscribe-to-lap-events.cs) |
-| React to new data arriving? | [`subscribe-to-data-events.cs`](snippets/csharp/live-data/subscribe-to-data-events.cs) |
-| Poll for the latest samples? | [`poll-live-samples.cs`](snippets/csharp/live-data/poll-live-samples.cs) |
-| Detect when new parameters appear? | [`rda-parameter-change-detection.cs`](snippets/csharp/live-data/rda-parameter-change-detection.cs) |
+| How do I... | C# | MATLAB |
+|------------|-----|--------|
+| React to new laps? | [`subscribe-to-lap-events.cs`](snippets/csharp/live-data/subscribe-to-lap-events.cs) | — |
+| React to new data arriving? | [`subscribe-to-data-events.cs`](snippets/csharp/live-data/subscribe-to-data-events.cs) | [`server_listener.m`](snippets/matlab/live-data/server_listener.m) |
+| Poll for the latest samples? | [`poll-live-samples.cs`](snippets/csharp/live-data/poll-live-samples.cs) | [`poll_live_samples.m`](snippets/matlab/live-data/poll_live_samples.m) |
+| Detect when new parameters appear? | [`rda-parameter-change-detection.cs`](snippets/csharp/live-data/rda-parameter-change-detection.cs) | — |
 
 ## Functions (Calculated Channels)
 
-| How do I... | C# |
-|------------|-----|
-| Create a calculated channel with FDL? | [`fdl-function-basic.cs`](snippets/csharp/functions/fdl-function-basic.cs) |
-| Create a calculated channel with .NET? | [`dotnet-function-basic.cs`](snippets/csharp/functions/dotnet-function-basic.cs) |
-| Use a PDA inside a .NET function? | [`dotnet-function-with-pda.cs`](snippets/csharp/functions/dotnet-function-with-pda.cs) |
+| How do I... | C# | MATLAB |
+|------------|-----|--------|
+| Create a calculated channel with FDL? | [`fdl-function-basic.cs`](snippets/csharp/functions/fdl-function-basic.cs) | — |
+| Create a calculated channel with .NET? | [`dotnet-function-basic.cs`](snippets/csharp/functions/dotnet-function-basic.cs) | — |
+| Use a PDA inside a .NET function? | [`dotnet-function-with-pda.cs`](snippets/csharp/functions/dotnet-function-with-pda.cs) | — |
+| Read calculated-channel (function) output? | — | [`read_function_output.m`](snippets/matlab/functions/read_function_output.m) |
 
 ## Composite Sessions
 
@@ -67,12 +70,12 @@ A task-based index: find the example you need by what you want to accomplish.
 
 ## Configuration
 
-| How do I... | C# |
-|------------|-----|
-| Set up parameter configuration manually? | [`create-parameter-config.cs`](snippets/csharp/configuration/create-parameter-config.cs) |
-| Create in-memory-only parameters? | [`create-transient-parameter.cs`](snippets/csharp/configuration/create-transient-parameter.cs) |
-| Inspect a session's configuration? | [`introspect-session-config.cs`](snippets/csharp/configuration/introspect-session-config.cs) |
-| Use different conversion types? | [`conversion-types.cs`](snippets/csharp/configuration/conversion-types.cs) |
+| How do I... | C# | MATLAB |
+|------------|-----|--------|
+| Set up parameter configuration manually? | [`create-parameter-config.cs`](snippets/csharp/configuration/create-parameter-config.cs) | [`create_session_write_data.m`](snippets/matlab/getting-started/create_session_write_data.m) |
+| Create in-memory-only parameters? | [`create-transient-parameter.cs`](snippets/csharp/configuration/create-transient-parameter.cs) | — |
+| Inspect a session's configuration? | [`introspect-session-config.cs`](snippets/csharp/configuration/introspect-session-config.cs) | [`introspect_session_config.m`](snippets/matlab/configuration/introspect_session_config.m) |
+| Use different conversion types? | [`conversion-types.cs`](snippets/csharp/configuration/conversion-types.cs) | — |
 
 ## Projects (Tier 2)
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,14 @@ dotnet run
 | Build timestamp arrays | C# | [`timestamp-array-construction.cs`](snippets/csharp/data-access/timestamp-array-construction.cs) |
 | Load a session | Python | [`01_load_session.py`](snippets/python/getting-started/01_load_session.py) |
 | Load a session | MATLAB | [`load_session.m`](snippets/matlab/getting-started/load_session.m) |
+| Connect to a SQL Server database | MATLAB | [`load_session_from_database.m`](snippets/matlab/getting-started/load_session_from_database.m) |
+| List all parameters in a session | MATLAB | [`list_parameters.m`](snippets/matlab/getting-started/list_parameters.m) |
+| Create a session and write data | MATLAB | [`create_session_write_data.m`](snippets/matlab/getting-started/create_session_write_data.m) |
+| Read data in a time range | MATLAB | [`read_samples_between.m`](snippets/matlab/data-access/read_samples_between.m) |
+| Plot a set of parameters | MATLAB | [`plot_parameters.m`](snippets/matlab/data-access/plot_parameters.m) |
+| Work with markers, laps, events, metadata | MATLAB | [`session-management/`](snippets/matlab/session-management/) |
+| Inspect session configuration and units | MATLAB | [`configuration/`](snippets/matlab/configuration/) |
+| Poll the latest live samples | MATLAB | [`poll_live_samples.m`](snippets/matlab/live-data/poll_live_samples.m) |
 
 See [COOKBOOK.md](COOKBOOK.md) for a complete task-based index.
 

--- a/snippets/matlab/README.md
+++ b/snippets/matlab/README.md
@@ -33,9 +33,70 @@ import MESL.SqlRace.Domain.*;
 | Wrong array types | Use `int64()` for timestamps, `double()` for values |
 | Memory issues with large datasets | Extract data in chunks; clear .NET objects when done |
 
+## Connecting to a database
+
+| Backend | Connection string |
+|---------|-------------------|
+| SQLite (`.ssn2` file) | `DbEngine=SQLite;Data Source=<path-to-file>.ssn2;` |
+| SQL Server | `Data Source=<server\instance>;Initial Catalog=<database>;Integrated Security=True;` |
+
+> **SQL Server has no `DbEngine=` prefix.** SQL Race passes SQL Server connection strings
+> straight to `SqlClient`, so use a standard SQL Server string. Adding `DbEngine=SQLServer;`
+> raises `Keyword not supported: 'dbengine'`. See
+> [`getting-started/load_session_from_database.m`](getting-started/load_session_from_database.m).
+
+## Additional assemblies
+
+The getting-started and session-management examples that **create** sessions (rather than
+just read them) need two more assemblies alongside `MESL.SqlRace.Domain.dll`:
+
+```matlab
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));            % SessionKey
+NET.addAssembly(fullfile(installDir, 'MESL.SqlRace.Enumerators.dll')); % DataType, ChannelDataSourceType, ...
+```
+
+Each snippet loads exactly what it needs in its setup block.
+
 ## Folders
 
 | Folder | Description |
 |--------|-------------|
-| [getting-started/](getting-started/) | Load sessions, read parameters, query metadata, verify setup |
-| [data-access/](data-access/) | Extract data to MATLAB timetables and arrays, per-segment statistics |
+| [getting-started/](getting-started/) | Load sessions, read parameters, query metadata, verify setup, create a session and write data |
+| [data-access/](data-access/) | Read samples in a time range, subsample, reverse iteration, status filtering, timetables, per-segment statistics |
+| [session-management/](session-management/) | Session metadata, markers, laps/segments, event extraction |
+| [configuration/](configuration/) | Introspect session configuration, resolve parameter units |
+| [functions/](functions/) | Read calculated-channel (function) output |
+| [live-data/](live-data/) | Poll the latest samples; server-listener live recording |
+
+## Snippets
+
+| File | Demonstrates |
+|------|-------------|
+| [getting-started/load_session.m](getting-started/load_session.m) | Load a session from SQLite |
+| [getting-started/load_session_from_database.m](getting-started/load_session_from_database.m) | Connect to a SQL Server SQL Race database and load a session |
+| [getting-started/read_parameters.m](getting-started/read_parameters.m) | Read samples into MATLAB arrays |
+| [getting-started/list_parameters.m](getting-started/list_parameters.m) | Catalogue every parameter (metadata + sample counts) and export to CSV |
+| [getting-started/query_sessions.m](getting-started/query_sessions.m) | Query sessions with a `ScalarFilter` |
+| [getting-started/create_session_write_data.m](getting-started/create_session_write_data.m) | Create a session with multi-rate parameters and write/read data |
+| [getting-started/diagnose_setup.m](getting-started/diagnose_setup.m) | Step-by-step setup verification |
+| [data-access/read_samples_between.m](data-access/read_samples_between.m) | `GetSamplesBetween` over a time range |
+| [data-access/subsampled_read.m](data-access/subsampled_read.m) | `GetData` with a custom timestamp array |
+| [data-access/reverse_iteration.m](data-access/reverse_iteration.m) | `GoTo` + `GetNextSamples(StepDirection.Reverse)` |
+| [data-access/data_status_filtering.m](data-access/data_status_filtering.m) | Filter samples by `DataStatus` |
+| [data-access/extract_to_timetable.m](data-access/extract_to_timetable.m) | Build a MATLAB timetable |
+| [data-access/multi_channel_read.m](data-access/multi_channel_read.m) | Read multiple parameters together |
+| [data-access/segment_statistics.m](data-access/segment_statistics.m) | Per-segment `GetLapStatistics` |
+| [data-access/plot_parameters.m](data-access/plot_parameters.m) | Extract a set of parameters and plot them on a shared time axis |
+| [session-management/session_metadata.m](session-management/session_metadata.m) | Write/read `SessionDataItem` metadata |
+| [session-management/marker_management.m](session-management/marker_management.m) | Create and read `Marker` annotations |
+| [session-management/lap_segment_management.m](session-management/lap_segment_management.m) | Create `Lap` segments |
+| [session-management/event_extraction.m](session-management/event_extraction.m) | Enumerate event definitions and read events per segment |
+| [configuration/introspect_session_config.m](configuration/introspect_session_config.m) | Enumerate parameters, groups, conversions |
+| [configuration/parameter_unit_resolution.m](configuration/parameter_unit_resolution.m) | Resolve units via `Session.GetConversion` |
+| [functions/read_function_output.m](functions/read_function_output.m) | Read calculated-channel (`:Functions`) output |
+| [live-data/poll_live_samples.m](live-data/poll_live_samples.m) | Poll the most recent samples |
+| [live-data/server_listener.m](live-data/server_listener.m) | Discover live sessions and follow live data (requires a live server) |
+
+> **Live data:** `server_listener.m` requires a reachable SQL Server recorder with a live
+> session and cannot run against the bundled SQLite scenario data. `poll_live_samples.m`
+> demonstrates the polling pattern and runs against any session.

--- a/snippets/matlab/configuration/introspect_session_config.m
+++ b/snippets/matlab/configuration/introspect_session_config.m
@@ -1,0 +1,101 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Introspect Session Configuration
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Enumerating a session's parameters, conversions, and groups
+%               to understand its configuration
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Summary tables of parameters, application groups, parameter groups
+%
+% Related: snippets/matlab/configuration/parameter_unit_resolution.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the turbine scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'turbine-week1.ssn2');
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    params = session.Parameters;
+    nParams = params.Count;
+
+    fprintf('Session: %s (%s)\n\n', char(session.Identifier), char(sessionKey.ToString()));
+
+    % --- Parameters ---
+    fprintf('=== Parameters (%d) ===\n', nParams);
+    fprintf('%-30s %-25s %-15s\n', 'Identifier', 'Conversion', 'AppGroup');
+    fprintf('%s\n', repmat('-', 1, 72));
+
+    appGroups = strings(0);
+    paramGroups = strings(0);
+    for i = 1:nParams
+        p = params.Item(i - 1);
+        fprintf('%-30s %-25s %-15s\n', char(p.Identifier), ...
+            char(p.ConversionFunctionName), char(p.ApplicationName));
+        appGroups(end+1) = string(char(p.ApplicationName)); %#ok<SAGROW>
+        g = p.GroupIdentifiers;
+        if ~isempty(g)
+            for j = 1:g.Count
+                paramGroups(end+1) = string(char(g.Item(j - 1))); %#ok<SAGROW>
+            end
+        end
+    end
+
+    % --- Application groups ---
+    fprintf('\n=== Application Groups ===\n');
+    for g = unique(appGroups)'
+        fprintf('  %s\n', g);
+    end
+
+    % --- Parameter groups ---
+    fprintf('\n=== Parameter Groups ===\n');
+    if isempty(paramGroups)
+        fprintf('  (none)\n');
+    else
+        for g = unique(paramGroups)'
+            fprintf('  %s\n', g);
+        end
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/configuration/parameter_unit_resolution.m
+++ b/snippets/matlab/configuration/parameter_unit_resolution.m
@@ -1,0 +1,91 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Parameter Unit Resolution
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Resolving the engineering unit for each parameter via its
+%               conversion (Session.GetConversion)
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Parameter details with resolved units, format, and range
+%
+% Related: snippets/matlab/configuration/introspect_session_config.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the turbine scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'turbine-week1.ssn2');
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    params = session.Parameters;
+
+    fprintf('Session: %s (%d parameters)\n\n', char(session.Identifier), params.Count);
+    fprintf('%-30s %-25s %-10s %-10s %s\n', ...
+        'Identifier', 'Conversion', 'Unit', 'Format', 'Range');
+    fprintf('%s\n', repmat('-', 1, 95));
+
+    for i = 1:params.Count
+        p = params.Item(i - 1);
+        conversionName = char(p.ConversionFunctionName);
+        unit = '(unknown)';
+        fmt = '';
+
+        % --- Resolve unit from the conversion ---
+        try
+            conversion = session.GetConversion(conversionName);
+            if ~isempty(conversion)
+                u = conversion.Units;
+                if ~isempty(u); unit = char(u); else; unit = '(none)'; end
+                f = conversion.FormatString;
+                if ~isempty(f); fmt = char(f); end
+            end
+        catch
+            unit = '(error)';
+        end
+
+        fprintf('%-30s %-25s %-10s %-10s [%.1f, %.1f]\n', ...
+            char(p.Identifier), conversionName, unit, fmt, ...
+            p.MinimumValue, p.MaximumValue);
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/data-access/data_status_filtering.m
+++ b/snippets/matlab/data-access/data_status_filtering.m
@@ -1,0 +1,102 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Data Status Filtering
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Checking DataStatus on returned samples to identify and
+%               handle missing or invalid data points
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Per-status breakdown and filtered valid-only values
+%
+% Related: snippets/matlab/data-access/read_samples_between.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the motorsport scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'motorsport-lap-analysis.ssn2');
+paramId = 'Speed:Shaft';
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    pda = session.CreateParameterDataAccess(paramId);
+    try
+        samples = pda.GetSamplesBetween(session.StartTime, session.EndTime);
+        n = samples.SampleCount;
+
+        % --- Count samples by status ---
+        % DataStatus values are .NET enums; convert to char for tallying.
+        statusNames = strings(n, 1);
+        for i = 1:n
+            statusNames(i) = string(char(samples.DataStatus(i).ToString()));
+        end
+        [uniqueStatuses, ~, idx] = unique(statusNames);
+        counts = accumarray(idx, 1);
+
+        fprintf('Parameter: %s\n', paramId);
+        fprintf('Total samples: %d\n\n', n);
+        fprintf('Status breakdown:\n');
+        for s = 1:numel(uniqueStatuses)
+            pct = 100 * counts(s) / n;
+            fprintf('  %-15s %6d (%.1f%%)\n', uniqueStatuses(s), counts(s), pct);
+        end
+
+        % --- Filter to valid samples only (DataStatusType.Sample) ---
+        fprintf('\nValid samples (Sample status):\n');
+        validMask = (statusNames == "Sample");
+        validIdx = find(validMask);
+        for k = 1:min(numel(validIdx), 10)
+            i = validIdx(k);
+            ms = double(samples.Timestamp(i) - session.StartTime) / 1e6;
+            fprintf('  t+%8.3f ms  %.4f\n', ms, samples.Data(i));
+        end
+        fprintf('Total valid: %d / %d\n', numel(validIdx), n);
+    catch ex
+        fprintf('Error reading data: %s\n', ex.message);
+    end
+    pda.Dispose();
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/data-access/plot_parameters.m
+++ b/snippets/matlab/data-access/plot_parameters.m
@@ -1,0 +1,114 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Plot Multiple Parameters
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Extracting the time-series for a set of parameters and
+%               plotting them on a shared time axis (one stacked subplot per
+%               parameter, so different value ranges stay readable)
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data) and a list
+%        of parameter identifiers to plot
+% Output: A figure window with one stacked subplot per parameter
+%
+% Related: snippets/matlab/data-access/multi_channel_read.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the turbine scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'turbine-week1.ssn2');
+
+% Parameters to plot (edit for your session; see list_parameters.m to discover them)
+parameterIds = {'Pressure:Inlet', 'Temperature:Sensors', 'RPM:Turbine'};
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    startNs = session.StartTime;
+
+    % --- Extract each parameter's time-series into MATLAB arrays ---
+    series = struct('id', {}, 't', {}, 'v', {});
+    for k = 1:numel(parameterIds)
+        paramId = parameterIds{k};
+        pda = session.CreateParameterDataAccess(paramId);
+        try
+            samples = pda.GetSamplesBetween(session.StartTime, session.EndTime);
+            n = samples.SampleCount;
+            t = zeros(n, 1);
+            v = zeros(n, 1);
+            for i = 1:n
+                t(i) = double(samples.Timestamp(i) - startNs) / 1e9;  % seconds
+                v(i) = samples.Data(i);
+            end
+            series(end+1) = struct('id', paramId, 't', t, 'v', v); %#ok<SAGROW>
+            fprintf('%-25s %d samples\n', paramId, n);
+        catch ex
+            fprintf('%-25s skipped — %s\n', paramId, ex.message);
+        end
+        pda.Dispose();
+    end
+
+    if isempty(series)
+        error('No data extracted for the requested parameters.');
+    end
+
+    % --- Plot: one stacked subplot per parameter, shared x-axis ---
+    fig = figure('Position', [100, 100, 900, 250 * numel(series)]);
+    tl = tiledlayout(fig, numel(series), 1, 'TileSpacing', 'compact', 'Padding', 'compact');
+    title(tl, sprintf('%s', char(session.Identifier)), 'Interpreter', 'none');
+
+    ax = gobjects(numel(series), 1);
+    for k = 1:numel(series)
+        ax(k) = nexttile(tl);
+        plot(ax(k), series(k).t, series(k).v, 'LineWidth', 1);
+        ylabel(ax(k), series(k).id, 'Interpreter', 'none');
+        grid(ax(k), 'on');
+    end
+    xlabel(ax(end), 'Time (s)');
+    linkaxes(ax, 'x');
+
+    fprintf('\nDisplayed %d parameter(s).\n', numel(series));
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/data-access/read_samples_between.m
+++ b/snippets/matlab/data-access/read_samples_between.m
@@ -1,0 +1,91 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Read Samples Between
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Using GetSamplesBetween to read data in a specific time range
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Sample count and the first samples within the requested range
+%
+% Related: snippets/matlab/data-access/reverse_iteration.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the motorsport scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'motorsport-lap-analysis.ssn2');
+paramId = 'Temperature:Sensors';
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+
+    % --- Define a time range: first 500 ms of data ---
+    rangeStart = session.StartTime;
+    rangeEnd = session.StartTime + int64(500e6);  % 0.5 s in nanoseconds
+
+    pda = session.CreateParameterDataAccess(paramId);
+    try
+        samples = pda.GetSamplesBetween(rangeStart, rangeEnd);
+
+        fprintf('Parameter: %s\n', paramId);
+        fprintf('Range:     %d - %d ns (%.3f s)\n', ...
+            rangeStart, rangeEnd, double(rangeEnd - rangeStart) / 1e9);
+        fprintf('Samples:   %d\n', samples.SampleCount);
+
+        nShow = min(samples.SampleCount, 10);
+        for i = 1:nShow
+            relMs = double(samples.Timestamp(i) - rangeStart) / 1e6;
+            fprintf('  t+%8.3f ms  %.4f\n', relMs, samples.Data(i));
+        end
+        if samples.SampleCount > 10
+            fprintf('  ... and %d more\n', samples.SampleCount - 10);
+        end
+    catch ex
+        fprintf('Error reading data: %s\n', ex.message);
+    end
+    pda.Dispose();
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/data-access/reverse_iteration.m
+++ b/snippets/matlab/data-access/reverse_iteration.m
@@ -1,15 +1,16 @@
 % ─────────────────────────────────────────────────────────────
-% SQL Race Example: Query Sessions
+% SQL Race Example: Reverse Iteration
 % ─────────────────────────────────────────────────────────────
 %
-% Demonstrates: Using QueryManager with ScalarFilter from MATLAB
+% Demonstrates: Using GoTo and GetNextSamples with StepDirection.Reverse to
+%               read data backwards from the end of a session
 % Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
 %                Run dotnetenv('core') once before using this snippet.
-% Input: A SQLite database with sessions
-% Output: Matching session identifiers and recording times
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Samples printed in reverse chronological order
 %
-% Related: snippets/matlab/getting-started/load_session.m
-% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% Related: snippets/matlab/data-access/read_samples_between.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
 % ─────────────────────────────────────────────────────────────
 
 % --- Configure .NET runtime (run once per MATLAB session) ---
@@ -31,64 +32,57 @@ end
 
 NET.addAssembly(sqlraceDll);
 import MESL.SqlRace.Domain.*;
-import MESL.SqlRace.Domain.Query.*;
+import MESL.SqlRace.Domain.Infrastructure.Enumerators.*;
 
 NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
 Core.Initialize();
 
-% --- Connection string ---
+% --- Connection and session ---
 % Default: use the flight-test scenario data file bundled in the repo
 dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
     'notebooks', 'scenarios', 'data');
 dbPath = fullfile(dataDir, 'flight-test-manoeuvre-extraction.ssn2');
+paramId = 'Temperature:Sensors';
 
 if ~exist(dbPath, 'file')
     error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
 end
 connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
 
-% --- Create query manager with filter ---
-qm = QueryManager.CreateQueryManager(connectionString);
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
 
-% 'Test' matches the bundled scenario sessions (e.g. "Flight Test FT-042").
-% Change this to filter for your own session identifiers.
-searchTerm = 'Test';
-queryFilter = ScalarFilter('Identifier', MatchingRule.Contains, searchTerm, false);
-qm.Filter = queryFilter;
+try
+    session = clientSession.Session;
+    pda = session.CreateParameterDataAccess(paramId);
+    try
+        % --- Position the PDA at the end of the session ---
+        pda.GoTo(session.EndTime);
 
-fprintf('Searching for sessions matching "%s"...\n', searchTerm);
-fprintf('%-40s %-30s %s\n', 'Session Key', 'Identifier', 'Recorded');
-fprintf('%s\n', repmat('-', 1, 94));
+        % --- Read 10 samples backwards ---
+        % StepDirection lives in MESL.SqlRace.Domain.Infrastructure.Enumerators
+        samples = pda.GetNextSamples(10, StepDirection.Reverse);
 
-queryResult = qm.ExecuteQuery();
+        fprintf('Parameter: %s\n', paramId);
+        fprintf('Last %d samples (reverse order):\n', samples.SampleCount);
+        fprintf('%20s  %12s\n', 'Timestamp (ns)', 'Value');
+        fprintf('%s\n', repmat('-', 1, 34));
 
-% --- Enumerate results via reflection (required for .NET Core interop) ---
-t = queryResult.GetType();
-ienumIface = t.GetInterface('System.Collections.IEnumerable');
-miGetEnum = ienumIface.GetMethod('GetEnumerator');
-emptyArgs = NET.createArray('System.Object', 0);
-en = miGetEnum.Invoke(queryResult, emptyArgs);
-
-ienumeratorT = System.Type.GetType('System.Collections.IEnumerator');
-miMoveNext = ienumeratorT.GetMethod('MoveNext');
-propCurrent = ienumeratorT.GetProperty('Current');
-miGetCurrent = propCurrent.GetGetMethod();
-
-count = 0;
-while miMoveNext.Invoke(en, emptyArgs)
-    summary = miGetCurrent.Invoke(en, emptyArgs);
-    fprintf('%-40s %-30s %s\n', ...
-        char(summary.Key.ToString()), ...
-        char(summary.Identifier), ...
-        char(summary.TimeOfRecording.ToString()));
-    count = count + 1;
-    if count >= 20
-        break;
+        for i = 1:samples.SampleCount
+            fprintf('%20d  %12.4f\n', samples.Timestamp(i), samples.Data(i));
+        end
+    catch ex
+        fprintf('Error reading data: %s\n', ex.message);
     end
+    pda.Dispose();
+catch ex
+    fprintf('Error: %s\n', ex.message);
 end
 
-if count == 0
-    disp('No sessions found. Run create_session_write_data.m to create some.');
-else
-    fprintf('\n%d session(s) found.\n', count);
-end
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/data-access/subsampled_read.m
+++ b/snippets/matlab/data-access/subsampled_read.m
@@ -1,0 +1,104 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Subsampled Read
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Using GetData with a custom timestamp array to downsample
+%               high-frequency data to a lower rate
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Values at the requested timestamps (every 100 ms = 10 Hz)
+%
+% Related: snippets/matlab/data-access/read_samples_between.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the turbine scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'turbine-week1.ssn2');
+paramId = 'Temperature:Sensors';
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+
+    % --- Build a custom timestamp array at 10 Hz (100 ms intervals) ---
+    desiredInterval = int64(100e6);  % 100 ms in nanoseconds (= 10 Hz)
+    startNs = session.StartTime;
+    endNs = session.EndTime;
+    sampleCount = double(idivide(endNs - startNs, desiredInterval));
+
+    if sampleCount <= 0
+        error('Session is too short for subsampling at 10 Hz.');
+    end
+
+    % Build a .NET int64 array of the desired timestamps
+    timestamps = NET.createArray('System.Int64', sampleCount);
+    for i = 1:sampleCount
+        timestamps(i) = startNs + int64(i - 1) * desiredInterval;
+    end
+
+    pda = session.CreateParameterDataAccess(paramId);
+    try
+        % --- Read data at the custom timestamps ---
+        samples = pda.GetData(timestamps);
+
+        fprintf('Parameter:       %s\n', paramId);
+        fprintf('Original range:  %d - %d ns\n', startNs, endNs);
+        fprintf('Subsampled to:   %d points at 10 Hz\n\n', sampleCount);
+
+        nShow = min(samples.SampleCount, 15);
+        for i = 1:nShow
+            relMs = double(samples.Timestamp(i) - startNs) / 1e6;
+            fprintf('  t+%8.1f ms  %.4f\n', relMs, samples.Data(i));
+        end
+        if samples.SampleCount > 15
+            fprintf('  ... and %d more\n', samples.SampleCount - 15);
+        end
+    catch ex
+        fprintf('Error reading data: %s\n', ex.message);
+    end
+    pda.Dispose();
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/functions/read_function_output.m
+++ b/snippets/matlab/functions/read_function_output.m
@@ -1,0 +1,101 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Read Function (Calculated Channel) Output
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Locating calculated-channel (function) parameters in the
+%               ":Functions" application group and reading their output the
+%               same way as any other parameter
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: List of function parameters and a sample of their output values
+%
+% Note: Function definitions are authored in ATLAS or via the .NET
+%       FunctionManager API. Once built, their output is read like any
+%       parameter — that is what this snippet shows. It reports gracefully
+%       if the session has no function parameters.
+%
+% Related: snippets/matlab/getting-started/read_parameters.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'motorsport-lap-analysis.ssn2');
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    params = session.Parameters;
+
+    % --- Find function parameters (calculated channels live in :Functions) ---
+    funcIds = strings(0);
+    for i = 1:params.Count
+        id = string(char(params.Item(i - 1).Identifier));
+        if endsWith(id, ':Functions')
+            funcIds(end+1) = id; %#ok<SAGROW>
+        end
+    end
+
+    fprintf('Session: %s\n', char(session.Identifier));
+    fprintf('Function parameters found: %d\n', numel(funcIds));
+
+    if isempty(funcIds)
+        fprintf(['\nNo function parameters in this session.\n' ...
+                 'Author a function in ATLAS (or via the .NET FunctionManager API),\n' ...
+                 'then re-run: its output appears as a "<name>:Functions" parameter\n' ...
+                 'and is read exactly like the example below.\n']);
+    else
+        for k = 1:numel(funcIds)
+            paramId = char(funcIds(k));
+            pda = session.CreateParameterDataAccess(paramId);
+            try
+                samples = pda.GetSamplesBetween(session.StartTime, session.EndTime);
+                fprintf('\n%s: %d samples\n', paramId, samples.SampleCount);
+                for i = 1:min(samples.SampleCount, 5)
+                    fprintf('  %20d ns  %.4f\n', samples.Timestamp(i), samples.Data(i));
+                end
+            catch ex
+                fprintf('  Error reading %s: %s\n', paramId, ex.message);
+            end
+            pda.Dispose();
+        end
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/getting-started/create_session_write_data.m
+++ b/snippets/matlab/getting-started/create_session_write_data.m
@@ -1,0 +1,135 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Create Session and Write Data
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Creating a SQLite session with multi-rate parameters,
+%               writing data, and reading it back to verify
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: None (creates its own .ssn2 file in the temp folder)
+% Output: Session key and verified samples for Temperature (100 Hz) and
+%         Pressure (50 Hz)
+%
+% Related: snippets/matlab/getting-started/read_parameters.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));
+enumDll = fullfile(installDir, 'MESL.SqlRace.Enumerators.dll');
+if exist(enumDll, 'file')
+    NET.addAssembly(enumDll);
+end
+import MESL.SqlRace.Domain.*;
+import MESL.SqlRace.Domain.Infrastructure.DataPipeline.*;
+import MESL.SqlRace.Enumerators.*;
+import MAT.OCS.Core.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection string (writable temp file) ---
+dbPath = fullfile(tempdir, 'sqlrace-matlab-examples.ssn2');
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+sessionKey = SessionKey.NewKey();
+
+% --- Create a new session ---
+sessionManager = SessionManager.CreateSessionManager();
+clientSession = sessionManager.CreateSession(connectionString, sessionKey, ...
+    'Example Session', System.DateTime.UtcNow, 'Example');
+
+try
+    session = clientSession.Session;
+
+    % --- Build parameter configuration ---
+    config = session.CreateConfiguration();
+    tempChannelId = uint32(1);
+    pressChannelId = uint32(2);
+    tempInterval = FrequencyExtensions.ToInterval(Frequency(100, FrequencyUnit.Hz));
+    pressInterval = FrequencyExtensions.ToInterval(Frequency(50, FrequencyUnit.Hz));
+
+    config.AddConversion(RationalConversion.CreateSimple1To1Conversion('degC_conv', 'degC', '%5.2f'));
+    config.AddConversion(RationalConversion.CreateSimple1To1Conversion('bar_conv', 'bar', '%5.3f'));
+
+    config.AddChannel(Channel(tempChannelId, 'Temperature', tempInterval, ...
+        DataType.Double64Bit, ChannelDataSourceType.Periodic, 'Temperature:Sensors', false));
+    config.AddChannel(Channel(pressChannelId, 'Pressure', pressInterval, ...
+        DataType.Double64Bit, ChannelDataSourceType.Periodic, 'Pressure:Inlet', false));
+
+    % Parameter groups expect a List<string> of group identifiers
+    thermalGroups = NET.createGeneric('System.Collections.Generic.List', {'System.String'});
+    thermalGroups.Add('Thermal');
+    hydraulicGroups = NET.createGeneric('System.Collections.Generic.List', {'System.String'});
+    hydraulicGroups.Add('Hydraulic');
+    appGroupChildren = NET.createGeneric('System.Collections.Generic.List', {'System.String'});
+    appGroupChildren.Add('Thermal');
+    appGroupChildren.Add('Hydraulic');
+
+    config.AddParameterGroup(ParameterGroup('Thermal', 'Thermal'));
+    config.AddParameterGroup(ParameterGroup('Hydraulic', 'Hydraulic'));
+    appGroup = ApplicationGroup('Sensors', 'Sensors', appGroupChildren);
+    appGroup.SupportsRda = false;
+    config.AddGroup(appGroup);
+
+    config.AddParameter(Parameter('Temperature:Sensors', 'Temperature', 'Inlet temperature sensor', ...
+        500, 0, 500, 0, 0.0, uint32(0), uint32(0), 'degC_conv', thermalGroups, tempChannelId, 'Sensors'));
+    config.AddParameter(Parameter('Pressure:Inlet', 'Pressure', 'Inlet pressure sensor', ...
+        10, 0, 10, 0, 0.0, uint32(0), uint32(0), 'bar_conv', hydraulicGroups, pressChannelId, 'Sensors'));
+
+    config.Commit();
+
+    % --- Write 1 second of data ---
+    startTime = int64(36e12);  % 10:00:00.000
+
+    for i = 0:99  % 100 Hz temperature
+        timestamp = startTime + int64(i) * tempInterval;
+        value = 20.0 + sin(i * 0.1) * 5.0;
+        session.AddChannelData(tempChannelId, timestamp, 1, System.BitConverter.GetBytes(value));
+    end
+
+    for i = 0:49  % 50 Hz pressure
+        timestamp = startTime + int64(i) * pressInterval;
+        value = 1.013 + sin(i * 0.05) * 0.2;
+        session.AddChannelData(pressChannelId, timestamp, 1, System.BitConverter.GetBytes(value));
+    end
+
+    % --- Read back and verify ---
+    tempPda = session.CreateParameterDataAccess('Temperature:Sensors');
+    tempSamples = tempPda.GetSamplesBetween(startTime, startTime + 100 * tempInterval);
+    pressPda = session.CreateParameterDataAccess('Pressure:Inlet');
+    pressSamples = pressPda.GetSamplesBetween(startTime, startTime + 50 * pressInterval);
+
+    fprintf('Session created: %s\n', char(sessionKey.ToString()));
+    fprintf('Connection:      %s\n\n', connectionString);
+    fprintf('Temperature:Sensors (100 Hz): %d samples\n', tempSamples.SampleCount);
+    fprintf('  First: %.2f degC  Last: %.2f degC\n', ...
+        tempSamples.Data(1), tempSamples.Data(tempSamples.SampleCount));
+    fprintf('Pressure:Inlet (50 Hz): %d samples\n', pressSamples.SampleCount);
+    fprintf('  First: %.3f bar  Last: %.3f bar\n', ...
+        pressSamples.Data(1), pressSamples.Data(pressSamples.SampleCount));
+
+    tempPda.Dispose();
+    pressPda.Dispose();
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/getting-started/list_parameters.m
+++ b/snippets/matlab/getting-started/list_parameters.m
@@ -1,0 +1,132 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: List All Parameters
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Enumerating every parameter in a session and building a
+%               MATLAB table catalogue (identifier, name, group, conversion,
+%               range, sample count), then exporting it to CSV
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: A printed parameter catalogue and a CSV written to the temp folder
+%
+% Related: snippets/matlab/getting-started/read_parameters.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the turbine scenario data file bundled in the repo
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'turbine-week1.ssn2');
+
+% Set to true to count samples per parameter (slower on large sessions)
+countSamples = true;
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    params = session.Parameters;
+    nParams = params.Count;
+
+    fprintf('Session: %s\n', char(session.Identifier));
+    fprintf('Parameters: %d\n\n', nParams);
+
+    % --- Pre-allocate columns for the catalogue table ---
+    Identifier  = strings(nParams, 1);
+    Name        = strings(nParams, 1);
+    Description = strings(nParams, 1);
+    AppGroup    = strings(nParams, 1);
+    Groups      = strings(nParams, 1);
+    Conversion  = strings(nParams, 1);
+    MinValue    = zeros(nParams, 1);
+    MaxValue    = zeros(nParams, 1);
+    Samples     = zeros(nParams, 1);
+
+    for i = 1:nParams
+        p = params.Item(i - 1);
+        Identifier(i)  = string(char(p.Identifier));
+        Name(i)        = string(char(p.Name));
+        Description(i) = string(char(p.Description));
+        AppGroup(i)    = string(char(p.ApplicationName));
+        Conversion(i)  = string(char(p.ConversionFunctionName));
+        MinValue(i)    = p.MinimumValue;
+        MaxValue(i)    = p.MaximumValue;
+
+        % Join the parameter group identifiers
+        g = p.GroupIdentifiers;
+        if ~isempty(g) && g.Count > 0
+            gnames = strings(1, g.Count);
+            for j = 1:g.Count
+                gnames(j) = string(char(g.Item(j - 1)));
+            end
+            Groups(i) = strjoin(gnames, '; ');
+        else
+            Groups(i) = "";
+        end
+
+        % Optionally count samples across the whole session
+        if countSamples
+            pda = session.CreateParameterDataAccess(char(p.Identifier));
+            try
+                s = pda.GetSamplesBetween(session.StartTime, session.EndTime);
+                Samples(i) = double(s.SampleCount);
+            catch
+                Samples(i) = NaN;
+            end
+            pda.Dispose();
+        else
+            Samples(i) = NaN;
+        end
+    end
+
+    % --- Build and display the catalogue table ---
+    catalogue = table(Identifier, Name, AppGroup, Groups, Conversion, ...
+        MinValue, MaxValue, Samples);
+    disp(catalogue);
+
+    % --- Export to CSV ---
+    csvPath = fullfile(tempdir, 'sqlrace-parameters.csv');
+    writetable(catalogue, csvPath);
+    fprintf('Catalogue written to: %s\n', csvPath);
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/getting-started/load_session_from_database.m
+++ b/snippets/matlab/getting-started/load_session_from_database.m
@@ -1,0 +1,100 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Load Session from a SQL Server Database
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Connecting to a SQL Server SQL Race database (rather than a
+%               local SQLite .ssn2 file), listing sessions, and loading one
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL,
+%                AND access to a SQL Server instance hosting a SQL Race
+%                database (e.g. SQLRACE01).
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A SQL Server connection string (edit the variables below, or set
+%        the SQLRACE_CONNECTION_STRING environment variable)
+% Output: A list of sessions and a summary of the most recent one
+%
+% Related: snippets/matlab/getting-started/load_session.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+
+% Pre-load Microsoft.Win32.SystemEvents — required when the runtime config
+% does not include Microsoft.WindowsDesktop.App (see docs/troubleshooting.md)
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- SQL Server connection string ---
+% Unlike SQLite (which uses a "DbEngine=SQLite;..." string), SQL Race passes
+% SQL Server strings straight to SqlClient — so use a standard SQL Server
+% connection string with NO DbEngine prefix. Integrated Security uses the
+% current Windows account (Trusted_Connection=True has the same effect).
+connectionString = getenv('SQLRACE_CONNECTION_STRING');
+if isempty(connectionString)
+    dataServer     = 'SERVER_NAME';   % SQL Server instance
+    initialCatalog = 'DATABASE_NAME';            % SQL Race database
+    connectionString = sprintf(['Data Source=%s;Initial Catalog=%s;' ...
+        'Integrated Security=True;'], dataServer, initialCatalog);
+end
+
+fprintf('Connecting to: %s\n', connectionString);
+
+sessionManager = SessionManager.CreateSessionManager();
+
+% --- List historical sessions on the server ---
+try
+    sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+catch ex
+    fprintf('ERROR: could not query the database: %s\n', ex.message);
+    fprintf(['Tips: check the server name/instance, that the SQLRACE01 catalog\n' ...
+             '      exists, and that your Windows account has access.\n']);
+    return;
+end
+
+fprintf('Found %d historical session(s).\n\n', sessions.Count);
+if sessions.Count == 0
+    disp('No sessions to load.');
+    return;
+end
+
+nShow = min(sessions.Count, 10);
+fprintf('%-40s %-30s %s\n', 'Session Key', 'Identifier', 'Recorded');
+fprintf('%s\n', repmat('-', 1, 94));
+for i = 1:nShow
+    s = sessions.Item(i - 1);
+    fprintf('%-40s %-30s %s\n', ...
+        char(s.Key.ToString()), char(s.Identifier), char(s.TimeOfRecording.ToString()));
+end
+
+% --- Load the most recent session and print a summary ---
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+try
+    session = clientSession.Session;
+    fprintf('\nLoaded: %s\n', char(session.Identifier));
+    fprintf('  Start time: %d ns\n', session.StartTime);
+    fprintf('  End time:   %d ns\n', session.EndTime);
+    fprintf('  Duration:   %.3f s\n', double(session.EndTime - session.StartTime) / 1e9);
+    fprintf('  Parameters: %d\n', session.Parameters.Count);
+    fprintf('  Laps:       %d\n', session.LapCollection.Count);
+catch ex
+    fprintf('Error reading session: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/live-data/poll_live_samples.m
+++ b/snippets/matlab/live-data/poll_live_samples.m
@@ -1,0 +1,93 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Poll Latest Samples
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Polling the most recent samples of a parameter by seeking to
+%               the end and reading backwards — the pattern used to monitor a
+%               live session
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data). For a live
+%        session, point the connection string at the live database/server.
+% Output: The latest samples at each poll cycle
+%
+% Note: Against historical data the latest values do not change between
+%       polls. Against a live session, each reload picks up newly flushed data.
+%
+% Related: snippets/matlab/data-access/reverse_iteration.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/parameter-data-access/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+import MESL.SqlRace.Domain.Infrastructure.Enumerators.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'motorsport-lap-analysis.ssn2');
+paramId = 'Speed:Shaft';
+nPolls = 3;          % number of poll cycles
+pollIntervalSec = 1; % delay between polls
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+
+fprintf('Polling %s every %ds (%d cycles)...\n\n', paramId, pollIntervalSec, nPolls);
+
+for pollNo = 1:nPolls
+    % --- Reload each cycle to pick up newly flushed data (live sessions) ---
+    clientSession = sessionManager.Load(sessionKey, connectionString);
+    try
+        session = clientSession.Session;
+        pda = session.CreateParameterDataAccess(paramId);
+        try
+            % Seek past the end, then read the most recent samples backwards
+            pda.GoTo(intmax('int64'));
+            samples = pda.GetNextSamples(5, StepDirection.Reverse);
+            if samples.SampleCount > 0
+                fprintf('  Poll %d: latest=%.2f at %d ns (%d recent)\n', ...
+                    pollNo, samples.Data(1), samples.Timestamp(1), samples.SampleCount);
+            else
+                fprintf('  Poll %d: no data yet\n', pollNo);
+            end
+        catch ex
+            fprintf('  Poll %d: error — %s\n', pollNo, ex.message);
+        end
+        pda.Dispose();
+    catch ex
+        fprintf('  Poll %d: load error — %s\n', pollNo, ex.message);
+    end
+    clientSession.Dispose();
+
+    if pollNo < nPolls
+        pause(pollIntervalSec);
+    end
+end
+
+fprintf('\nPolling complete — %d polls.\n', nPolls);

--- a/snippets/matlab/live-data/server_listener.m
+++ b/snippets/matlab/live-data/server_listener.m
@@ -1,0 +1,113 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Server Listener (Live Recording)
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Configuring a SQL Race server listener, discovering live
+%               sessions on an ATLAS Data Server, and reading the latest data
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL,
+%                AND a reachable SQL Server recorder with a live session.
+%                Run dotnetenv('core') once before using this snippet.
+% Input: Recorder connection details (edit the variables below)
+% Output: Live session discovery and a short live-data read loop
+%
+% Note: This snippet REQUIRES a live ATLAS Data Server / SQL Server recorder.
+%       It cannot run against the bundled SQLite scenario data. Edit the
+%       connection details below for your environment before running.
+%
+% Related: snippets/matlab/live-data/poll_live_samples.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/live-data/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assemblies and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));
+import MESL.SqlRace.Domain.*;
+import MESL.SqlRace.Domain.Infrastructure.Enumerators.*;
+import MESL.SqlRace.Domain.Remoting.Server.*;
+import MAT.OCS.Core.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Recorder / server configuration (edit for your environment) ---
+recorderDbEngine = 'SQLServer';
+databaseName     = 'SQLRACE01';
+recorderDataServer = 'MACHINE\LOCAL';
+serverListenerIp   = '127.0.0.1';
+serverListenerPort = 6566;
+parameterId        = 'vCar:Chassis';
+
+connStr = sprintf('server=%s;Initial Catalog=%s;Trusted_Connection=True;', ...
+    recorderDataServer, databaseName);
+
+% --- Configure the server listener endpoint ---
+ipAddr = System.Net.IPAddress.Parse(serverListenerIp);
+endPoint = System.Net.IPEndPoint(ipAddr, int32(serverListenerPort));
+Core.ConfigureServer(true, endPoint);
+
+recordersConfiguration = RecordersConfiguration.GetRecordersConfiguration();
+recordersConfiguration.AddConfiguration(System.Guid.NewGuid(), recorderDbEngine, ...
+    recorderDataServer, recorderDataServer, connStr, false);
+
+sessionManager = SessionManager.CreateSessionManager();
+
+% --- Find live sessions ---
+activeSessions = sessionManager.FindBySessionState(SessionState.Live, connStr);
+fprintf('Found %d live session(s).\n', activeSessions.Count);
+
+if activeSessions.Count == 0
+    fprintf('No live sessions. Start a recording on the server and re-run.\n');
+    recordersConfiguration.RemoveConfiguration();
+    return;
+end
+
+% --- Load the most recent live session ---
+summary = activeSessions.Item(activeSessions.Count - 1);
+fprintf('Loading live session: %s\n', char(summary.Identifier));
+clientSession = sessionManager.Load(summary.Key, summary.GetConnectionString());
+
+try
+    liveSession = clientSession.Session;
+    liveSession.LoadConfiguration();
+
+    if liveSession.Parameters.Count == 0
+        fprintf('Session contains no parameters.\n');
+    else
+        pda = liveSession.CreateParameterDataAccess(parameterId);
+        try
+            % Follow the live edge: read forward from the current end
+            pda.GoTo(liveSession.EndTime);
+            for iter = 1:10
+                samples = pda.GetNextSamples(int32(50), StepDirection.Forward);
+                if samples.SampleCount > 0
+                    fprintf('Iter %d: %d new sample(s), latest=%.3f\n', ...
+                        iter, samples.SampleCount, samples.Data(samples.SampleCount));
+                else
+                    fprintf('Iter %d: waiting for data...\n', iter);
+                end
+                pause(1);
+            end
+        catch ex
+            fprintf('Error reading live data: %s\n', ex.message);
+        end
+        pda.Dispose();
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Close();
+recordersConfiguration.RemoveConfiguration();
+disp('Done.');

--- a/snippets/matlab/session-management/event_extraction.m
+++ b/snippets/matlab/session-management/event_extraction.m
@@ -1,0 +1,109 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Event Extraction
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Enumerating EventDefinitions and reading event instances
+%               per segment with GetEventData / GetDisplayText
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: A .ssn2 SQLite database file (defaults to scenario data)
+% Output: Event definitions and a per-segment breakdown of event instances
+%
+% Note: Event *creation* happens in the recording/import pipeline. This
+%       snippet reads events; it reports zero events if the session has none.
+%
+% Related: snippets/matlab/session-management/marker_management.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assembly and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+import MESL.SqlRace.Domain.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection and session ---
+% Default: use the motorsport scenario data file (multiple segments)
+dataDir = fullfile(fileparts(mfilename('fullpath')), '..', '..', '..', ...
+    'notebooks', 'scenarios', 'data');
+dbPath = fullfile(dataDir, 'motorsport-lap-analysis.ssn2');
+
+if ~exist(dbPath, 'file')
+    error('File not found: %s\nCheck that notebooks/scenarios/data/ contains the .ssn2 files.', dbPath);
+end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+
+sessionManager = SessionManager.CreateSessionManager();
+sessions = sessionManager.FindBySessionState(SessionState.Historical, connectionString);
+if sessions.Count == 0
+    error('No sessions found in %s', dbPath);
+end
+sessionKey = sessions.Item(0).Key;
+clientSession = sessionManager.Load(sessionKey, connectionString);
+
+try
+    session = clientSession.Session;
+    fprintf('Session: %s\n', char(session.Identifier));
+
+    % --- List event definitions (the catalogue of possible event types) ---
+    defs = session.EventDefinitions;
+    fprintf('Event definitions: %d\n', defs.Count);
+    for i = 1:defs.Count
+        def = defs.Item(i - 1);
+        fprintf('  [%s] %s (priority %s)\n', ...
+            char(def.EventDefinitionId), char(def.Description), char(def.Priority.ToString()));
+    end
+
+    % --- Read event instances per segment ---
+    laps = session.LapCollection;
+    eventCollection = session.Events;
+    fprintf('\nReading events across %d segment(s):\n', laps.Count);
+    fprintf('%-18s %12s\n', 'Segment', 'Events');
+    fprintf('%s\n', repmat('-', 1, 32));
+
+    totalEvents = 0;
+    for n = 1:laps.Count
+        lap = laps.Item(n - 1);
+        lapEnd = lap.EndTime;
+        if lapEnd.HasValue
+            endTs = lapEnd.Value;
+        else
+            endTs = session.EndTime;
+        end
+        events = eventCollection.GetEventData(lap.StartTime, endTs);
+        fprintf('%-18s %12d\n', char(lap.Name), events.Count);
+        totalEvents = totalEvents + double(events.Count);
+
+        % Show the first few events in this segment, if any
+        for j = 1:min(events.Count, 5)
+            evt = events.Item(j - 1);
+            statusText = char(eventCollection.GetDisplayText(evt));
+            fprintf('    t=%d ns  def=%s  %s\n', ...
+                evt.TimeStamp, char(string(evt.EventDefinitionKey)), statusText);
+        end
+    end
+
+    fprintf('\nTotal events: %d\n', totalEvents);
+    if totalEvents == 0
+        fprintf('(This session contains no event instances — events are written by\n');
+        fprintf(' the recording/import pipeline, e.g. ATLAS or a ServerListener recorder.)\n');
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/session-management/lap_segment_management.m
+++ b/snippets/matlab/session-management/lap_segment_management.m
@@ -1,0 +1,75 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Lap and Segment Management
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Creating Lap objects as test segments and reading them back
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: None (creates its own .ssn2 file in the temp folder)
+% Output: Segment list with name, start time, and offset
+%
+% Related: snippets/matlab/session-management/marker_management.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assemblies and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));
+import MESL.SqlRace.Domain.*;
+import MAT.OCS.Core.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection string (writable temp file) ---
+dbPath = fullfile(tempdir, 'sqlrace-matlab-segments.ssn2');
+if exist(dbPath, 'file'); delete(dbPath); end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+sessionKey = SessionKey.NewKey();
+
+sessionManager = SessionManager.CreateSessionManager();
+clientSession = sessionManager.CreateSession(connectionString, sessionKey, ...
+    'Segment Demo', System.DateTime.UtcNow, 'Example');
+
+try
+    session = clientSession.Session;
+    baseTime = int64(36e12);  % 10:00:00.000
+
+    % --- Add segments (laps) representing test phases ---
+    % Lap ctor: (Int64 startTime, Int16 number, Byte triggerSource, String name, Boolean countForFastestLap)
+    names   = {'Warmup', 'Steady State 1', 'Ramp Up', 'Steady State 2', 'Cooldown'};
+    offsets = int64([0, 60e9, 180e9, 240e9, 360e9]);
+
+    for i = 1:numel(names)
+        lap = Lap(baseTime + offsets(i), int16(i), uint8(0), names{i}, false);
+        session.LapCollection.Add(lap);
+    end
+
+    fprintf('Session %s: %d segments\n\n', ...
+        char(sessionKey.ToString()), session.LapCollection.Count);
+    fprintf('%3s %-20s %20s %12s\n', '#', 'Name', 'Start (ns)', 'Offset (s)');
+    fprintf('%s\n', repmat('-', 1, 58));
+
+    for i = 1:session.LapCollection.Count
+        lap = session.LapCollection.Item(i - 1);
+        offsetS = double(lap.StartTime - baseTime) / 1e9;
+        fprintf('%3d %-20s %20d %12.0f\n', lap.Number, char(lap.Name), lap.StartTime, offsetS);
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/session-management/marker_management.m
+++ b/snippets/matlab/session-management/marker_management.m
@@ -1,0 +1,81 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Marker Management
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Creating Marker objects with time ranges and annotations
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: None (creates its own .ssn2 file in the temp folder)
+% Output: Markers with labels and durations printed to the command window
+%
+% Related: snippets/matlab/session-management/lap_segment_management.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assemblies and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));
+import MESL.SqlRace.Domain.*;
+import MAT.OCS.Core.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection string (writable temp file) ---
+dbPath = fullfile(tempdir, 'sqlrace-matlab-markers.ssn2');
+if exist(dbPath, 'file'); delete(dbPath); end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+sessionKey = SessionKey.NewKey();
+
+sessionManager = SessionManager.CreateSessionManager();
+clientSession = sessionManager.CreateSession(connectionString, sessionKey, ...
+    'Marker Demo', System.DateTime.UtcNow, 'Example');
+
+try
+    session = clientSession.Session;
+    baseTime = int64(36e12);  % 10:00:00.000
+
+    % --- Add markers representing annotated time regions ---
+    % 6-argument ctor: (startTimestamp, endTimestamp, label, markerType, description, guid)
+    anomaly = Marker(baseTime, baseTime + int64(2e9), ...
+        'Anomaly', 'Anomaly', 'Unexpected temperature spike detected', char(System.Guid.NewGuid().ToString()));
+    roi = Marker(baseTime + int64(5e9), baseTime + int64(8e9), ...
+        'RegionOfInterest', 'RegionOfInterest', 'Steady-state operating window', char(System.Guid.NewGuid().ToString()));
+    transient = Marker(baseTime + int64(10e9), baseTime + int64(12e9), ...
+        'Transient', 'Transient', 'Load step response period', char(System.Guid.NewGuid().ToString()));
+
+    session.Markers.Add(anomaly);
+    session.Markers.Add(roi);
+    session.Markers.Add(transient);
+
+    fprintf('Session %s: %d markers added\n\n', ...
+        char(sessionKey.ToString()), session.Markers.Count);
+
+    for i = 1:session.Markers.Count
+        marker = session.Markers.Item(i - 1);
+        startNs = int64(0); endNs = int64(0);
+        if marker.StartTimestamp.HasValue; startNs = marker.StartTimestamp.Value; end
+        if marker.EndTimestamp.HasValue;   endNs   = marker.EndTimestamp.Value;   end
+        durationS = double(endNs - startNs) / 1e9;
+        fprintf('  [%s] %d-%d ns (%.1fs)\n', char(marker.Label), startNs, endNs, durationS);
+        fprintf('    Type: %s\n', char(marker.MarkerType));
+        fprintf('    Description: %s\n\n', char(marker.Description));
+    end
+catch ex
+    fprintf('Error: %s\n', ex.message);
+end
+
+clientSession.Dispose();
+disp('Done.');

--- a/snippets/matlab/session-management/session_metadata.m
+++ b/snippets/matlab/session-management/session_metadata.m
@@ -1,0 +1,76 @@
+% ─────────────────────────────────────────────────────────────
+% SQL Race Example: Session Metadata
+% ─────────────────────────────────────────────────────────────
+%
+% Demonstrates: Creating and reading SessionDataItem entries on a session
+% Prerequisites: MATLAB R2023a+, .NET 8 runtime, MESL.SqlRace.Domain DLL
+%                Run dotnetenv('core') once before using this snippet.
+% Input: None (creates its own .ssn2 file in the temp folder)
+% Output: Session data items written and read back after reload
+%
+% Related: snippets/matlab/session-management/marker_management.m
+% Docs: https://atlas.motionapplied.com/developer-resources/atlas/sql-race/examples/session-loading/
+% ─────────────────────────────────────────────────────────────
+
+% --- Configure .NET runtime (run once per MATLAB session) ---
+% dotnetenv('core');  % uncomment if not already set
+
+% --- Load assemblies and initialise ---
+sqlraceDll = getenv('SQLRACE_DLL_PATH');
+if isempty(sqlraceDll)
+    sqlraceDll = 'C:\Program Files\McLaren Applied Technologies\ATLAS 10\MESL.SqlRace.Domain.dll';
+end
+installDir = fileparts(sqlraceDll);
+sysEventsDll = fullfile(installDir, 'Microsoft.Win32.SystemEvents.dll');
+if exist(sysEventsDll, 'file')
+    NET.addAssembly(sysEventsDll);
+end
+NET.addAssembly(sqlraceDll);
+NET.addAssembly(fullfile(installDir, 'MAT.OCS.Core.dll'));
+import MESL.SqlRace.Domain.*;
+import MAT.OCS.Core.*;
+
+NET.setStaticProperty('MESL.SqlRace.Domain.Core.LicenceProgramName', 'SQLRace');
+Core.Initialize();
+
+% --- Connection string (writable temp file) ---
+dbPath = fullfile(tempdir, 'sqlrace-matlab-metadata.ssn2');
+if exist(dbPath, 'file'); delete(dbPath); end
+connectionString = sprintf('DbEngine=SQLite;Data Source=%s;', dbPath);
+sessionKey = SessionKey.NewKey();
+
+sessionManager = SessionManager.CreateSessionManager();
+
+% --- Create a session and add metadata items ---
+client = sessionManager.CreateSession(connectionString, sessionKey, ...
+    'Metadata Demo', System.DateTime.UtcNow, 'Example');
+try
+    session = client.Session;
+    session.Items.Add(SessionDataItem('Facility', 'Wind Tunnel A'));
+    session.Items.Add(SessionDataItem('Operator', 'Test Engineer 1'));
+    session.Items.Add(SessionDataItem('TestObjective', 'Thermal characterisation at 80% load'));
+    session.Items.Add(SessionDataItem('AmbientTemp', '22.5'));
+    session.Items.Add(SessionDataItem('RunNumber', '42'));
+    fprintf('Created session %s with %d metadata items\n', ...
+        char(sessionKey.ToString()), session.Items.Count);
+catch ex
+    fprintf('Error writing metadata: %s\n', ex.message);
+end
+client.Dispose();
+
+% --- Reload and read back ---
+reloaded = sessionManager.Load(sessionKey, connectionString);
+try
+    reloadedSession = reloaded.Session;
+    fprintf('\nReloaded session: %d metadata items\n', reloadedSession.Items.Count);
+    fprintf('%-20s %s\n', 'Key', 'Value');
+    fprintf('%s\n', repmat('-', 1, 60));
+    for i = 1:reloadedSession.Items.Count
+        item = reloadedSession.Items.Item(i - 1);
+        fprintf('%-20s %s\n', char(item.Name), char(item.Value));
+    end
+catch ex
+    fprintf('Error reading metadata: %s\n', ex.message);
+end
+reloaded.Dispose();
+disp('Done.');


### PR DESCRIPTION
Expand the MATLAB snippet tier to mirror the C# categories:

- getting-started: create_session_write_data, list_parameters, load_session_from_database

- data-access: read_samples_between, subsampled_read, reverse_iteration, data_status_filtering, plot_parameters

- session-management: session_metadata, marker_management, lap_segment_management, event_extraction

- configuration: introspect_session_config, parameter_unit_resolution

- functions: read_function_output

- live-data: poll_live_samples, server_listener

Align query_sessions with the bundled scenario data and update the MATLAB README, COOKBOOK, and top-level README indexes.